### PR TITLE
Upgrade to PhpUnit 6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
         "php": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^6.1"
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -4,10 +4,10 @@ namespace Frank\Test;
 
 use Frank\Enum;
 use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
-use PHPUnit_Framework_TestCase;
 
-class EnumTest extends PHPUnit_Framework_TestCase
+class EnumTest extends TestCase
 {
     public function testValidConstruction()
     {


### PR DESCRIPTION
PhpUnit 5.7 is pretty old. For future appliances it makes sense to use a recent
version of PhpUnit. Currently, it's still easy to do so since there's just 1 test