### PR TITLE
Add ofList method to create a list of Enum's

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.1"

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -173,6 +173,15 @@ abstract class Enum
     }
 
     /**
+     * @param mixed[] $values
+     * @return static[]
+     */
+    public final static function ofList(array $values): array
+    {
+        return \array_map(static fn($value) => self::of($value), $values);
+    }
+
+    /**
      * Makes it possible to easily instantiate an Enum by statically calling the
      * constant name to
      * @param $name

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -192,6 +192,11 @@ class EnumTest extends TestCase
         $this->assertTrue(_EnumTest::FOO()->equalsAny(_EnumTest::all()));
         $this->assertFalse(_EnumTest::FOO()->equalsAny([_EnumTest::NONE(), _EnumTest::BAR(), new class() {}]));
     }
+
+    public function testOfList()
+    {
+        $this->assertEquals([_EnumTest::FOO(), _EnumTest::BAR()], _EnumTest::ofList([_EnumTest::FOO, _EnumTest::BAR]));
+    }
 }
 
 /**


### PR DESCRIPTION
``` lang=php
Enum::ofList($values);
```

is way more readable than

``` lang=php
array_map(
    static fn($value) => new Enum($value),
    $values
);
```

Especially when creating an object that needs multiple `Enum`s