### PR TITLE
Forbid cloning an enum

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -34,12 +34,16 @@ abstract class Enum implements \Stringable
     /**
      * @param mixed $value
      */
-    private function __construct($value)
+    final private function __construct($value)
     {
         if (!static::isValidValue($value)) {
             throw new InvalidArgumentException(sprintf('%s is not a valid value for %s', $value, static::class));
         }
         $this->value = $value;
+    }
+
+    final private function __clone()
+    {
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -212,6 +212,12 @@ class EnumTest extends TestCase
         $this->expectExceptionMessage('I_AM_PROTECTED does not exist in ' . TestEnum::class);
         TestEnum::I_AM_PROTECTED();
     }
+
+    public function testCloningIsForbidden()
+    {
+        $this->expectException(\Error::class);
+        clone TestEnum::BAR();
+    }
 }
 
 /**


### PR DESCRIPTION
Enums are value objects, so cloning them is almost definitely a mistake.