### PR TITLE
Fix the PHP8.0 warning about private methods not allowed being final

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -42,7 +42,7 @@ abstract class Enum implements \Stringable
         $this->value = $value;
     }
 
-    final private function __clone()
+    private function __clone()
     {
     }
 


### PR DESCRIPTION
Declaring a class method `final private` does not make sense because all `private` class methods are inaccessible by child classes anyway.

See also: https://php.watch/versions/8.0/final-private-function#final-private